### PR TITLE
Change peer dependency on Jasmine to Jasmine Core

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "peerDependencies": {
     "karma": ">=0.9",
     "karma-jasmine": ">=1.1",
-    "jasmine": ">=3"
+    "jasmine-core": ">=3"
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
This will fix the following npm warning:
```
npm WARN karma-jasmine-html-reporter@1.1.0 requires a peer of jasmine@>=3 but none is installed. You must install peer dependencies yourself.
```