### PR TITLE
Updated Jasmine-core to a dependency of version 3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-jasmine-html-reporter",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -54,7 +54,8 @@
     "jasmine-core": {
       "version": "3.2.1",
       "resolved": "http://npm-packages.rmdev.zone/jasmine-core/-/jasmine-core-3.2.1.tgz",
-      "integrity": "sha512-pa9tbBWgU0EE4SWgc85T4sa886ufuQdsgruQANhECYjwqgV4z7Vw/499aCaP8ZH79JDS4vhm8doDG9HO4+e4sA=="
+      "integrity": "sha512-pa9tbBWgU0EE4SWgc85T4sa886ufuQdsgruQANhECYjwqgV4z7Vw/499aCaP8ZH79JDS4vhm8doDG9HO4+e4sA==",
+      "dev": true
     },
     "supports-color": {
       "version": "5.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
     },
     "jasmine-core": {
       "version": "3.2.1",
-      "resolved": "http://npm-packages.rmdev.zone/jasmine-core/-/jasmine-core-3.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.2.1.tgz",
       "integrity": "sha512-pa9tbBWgU0EE4SWgc85T4sa886ufuQdsgruQANhECYjwqgV4z7Vw/499aCaP8ZH79JDS4vhm8doDG9HO4+e4sA==",
       "dev": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,10 +52,9 @@
       "dev": true
     },
     "jasmine-core": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.2.0.tgz",
-      "integrity": "sha512-35OOToo2lFczwZ/FdJkUOO/Gsp9FW7viWChYA7OgBfpjgTxbxmNKyNrGS3HHREHay5nJwJvu4RqAlvcBcCAWeA==",
-      "dev": true
+      "version": "3.2.1",
+      "resolved": "http://npm-packages.rmdev.zone/jasmine-core/-/jasmine-core-3.2.1.tgz",
+      "integrity": "sha512-pa9tbBWgU0EE4SWgc85T4sa886ufuQdsgruQANhECYjwqgV4z7Vw/499aCaP8ZH79JDS4vhm8doDG9HO4+e4sA=="
     },
     "supports-color": {
       "version": "5.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,9 +58,9 @@
       "dev": true
     },
     "supports-color": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
       "requires": {
         "has-flag": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-jasmine-html-reporter",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "A Karma plugin. Dynamically displays tests results at debug.html page",
   "main": "./src/index.js",
   "keywords": [
@@ -31,6 +31,10 @@
     {
       "name": "protazy",
       "url": "https://github.com/protazy"
+    },
+    {
+      "name": "footballencarta",
+      "url": "https://github.com/footballencarta"
     }
   ],
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -37,16 +37,15 @@
       "url": "https://github.com/footballencarta"
     }
   ],
-  "dependencies": {
-    "jasmine-core": ">=3.2"
-  },
   "peerDependencies": {
     "karma": ">=0.9",
-    "karma-jasmine": ">=1.1"
+    "karma-jasmine": ">=1.1",
+    "jasmine-core": ">=3.2"
   },
   "license": "MIT",
   "devDependencies": {
-    "chalk": "*"
+    "chalk": "*",
+    "jasmine-core": ">=3.2"
   },
   "readmeFilename": "README.md"
 }

--- a/package.json
+++ b/package.json
@@ -33,15 +33,16 @@
       "url": "https://github.com/protazy"
     }
   ],
+  "dependencies": {
+    "jasmine-core": ">=3.2"
+  },
   "peerDependencies": {
     "karma": ">=0.9",
-    "karma-jasmine": ">=1.1",
-    "jasmine-core": ">=3"
+    "karma-jasmine": ">=1.1"
   },
   "license": "MIT",
   "devDependencies": {
-    "chalk": "*",
-    "jasmine-core": ">=3"
+    "chalk": "*"
   },
   "readmeFilename": "README.md"
 }


### PR DESCRIPTION
Referencing #14 - jasmine 3.2 is now required for the latest version of the plugin to work.

Added it as a dependancy to allow projects to pick up the package difference and process accordingly.