### PR TITLE
fix: always override specFilter if query exists

### DIFF
--- a/src/lib/adapter.js
+++ b/src/lib/adapter.js
@@ -64,7 +64,7 @@
    * Filter which specs will be run by matching the start of the full name against the `spec` query param.
    */
   var specFilter;
-  if (!config.specFilter || queryString.getParam("spec")) {
+  if (queryString.getParam("spec")) {
     specFilter = new jasmine.HtmlSpecFilter({
       filterString: function () { return queryString.getParam("spec"); }
     });


### PR DESCRIPTION
Retries #24 

The previous PR had two problems:

1. Incorrect to check `config.specFilter` as it's always `undefined` because `config` is our own configuration object rather than jasmine global one.
2. Incorrect to check existence of `specFilter` as even the jasmine global configuration always have `specFilter` which always returns `true`.

I think adding a query means the user wants to override the existing filter, so maybe better to do this way.