### PR TITLE
Add a width to the top level jasmin_html-reporter class

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-jasmine-html-reporter",
-  "version": "1.3.1",
+  "version": "1.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-jasmine-html-reporter",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "A Karma plugin. Dynamically displays tests results at debug.html page",
   "main": "./src/index.js",
   "keywords": [

--- a/src/css/jasmine.css
+++ b/src/css/jasmine.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 body { overflow-y: scroll; }
 
-.jasmine_html-reporter { background-color: #eee; padding: 5px; margin: -8px; font-size: 11px; font-family: Monaco, "Lucida Console", monospace; line-height: 14px; color: #333; }
+.jasmine_html-reporter { width: 100%; background-color: #eee; padding: 5px; margin: -8px; font-size: 11px; font-family: Monaco, "Lucida Console", monospace; line-height: 14px; color: #333; }
 .jasmine_html-reporter a { text-decoration: none; }
 .jasmine_html-reporter a:hover { text-decoration: underline; }
 .jasmine_html-reporter p, .jasmine_html-reporter h1, .jasmine_html-reporter h2, .jasmine_html-reporter h3, .jasmine_html-reporter h4, .jasmine_html-reporter h5, .jasmine_html-reporter h6 { margin: 0; line-height: 14px; }

--- a/src/lib/adapter.js
+++ b/src/lib/adapter.js
@@ -64,7 +64,7 @@
    * Filter which specs will be run by matching the start of the full name against the `spec` query param.
    */
   var specFilter;
-  if (!config.specFilter || queryString.getParam("spec")) {
+  if (queryString.getParam("spec")) {
     specFilter = new jasmine.HtmlSpecFilter({
       filterString: function () { return queryString.getParam("spec"); }
     });


### PR DESCRIPTION
When iFramed in Angular projects, sometimes, for some reason, the width of this element is allowed to expand beyond the sides of the page. Adding a fixed width of 100% seems to fix this problem and shouldn't cause too much trouble elsewhere; we'd expect the reporter to be 100% of its parent width. 

