### PR TITLE
Added options object to be able to overwrite logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,24 @@ npm install karma-jasmine-html-reporter --save-dev
 // karma.conf.js
 module.exports = function(config) {
   config.set({
+    reporters: ['kjhtml']
+  });
+};
+```
+#### With options
+In combination with multiple reporters you may want to disable failed messages because it's already handled by another reporter.
 
-    reporters: ['kjhtml'],
+*Example when using the 'karma-mocha-reporter' plugin*:
+```js
+// karma.conf.js
+module.exports = function(config) {
+  config.set({
+
+    // Combine multiple reporters
+    reporters: ['kjhtml', 'mocha'],
 
     jasmineHtmlReporter: {
-      // Suppress failed messages (e.g. in combination with karma-mocha-reporter)
+      // Suppress failed messages
       suppressFailed: true
     }
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,14 @@ npm install karma-jasmine-html-reporter --save-dev
 // karma.conf.js
 module.exports = function(config) {
   config.set({
-    reporters: ['kjhtml']
+
+    reporters: ['kjhtml'],
+
+    jasmineHtmlReporter: {
+      // Suppress failed messages (e.g. in combination with karma-mocha-reporter)
+      suppressFailed: true
+    }
+
   });
 };
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -3,10 +3,19 @@ var createPattern = function (path) {
   return { pattern: path, included: true, served: true, watched: false };
 };
 
-var initReporter = function (files, baseReporterDecorator) {
+var initReporter = function (karmaConfig, baseReporterDecorator) {
   var jasmineCoreIndex = 0;
 
+  const files = karmaConfig.files;
+
   baseReporterDecorator(this);
+
+  if (karmaConfig.jasmineHtmlReporter) {
+    const config = karmaConfig.jasmineHtmlReporter;
+    if (config.suppressFailed) {
+      this.specFailure = () => void 0;
+    }
+  }
 
   files.forEach(function (file, index) {
     if (JASMINE_CORE_PATTERN.test(file.pattern)) {
@@ -19,7 +28,7 @@ var initReporter = function (files, baseReporterDecorator) {
   files.splice(++jasmineCoreIndex, 0, createPattern(__dirname + '/lib/adapter.js'));
 };
 
-initReporter.$inject = ['config.files', 'baseReporterDecorator'];
+initReporter.$inject = ['config', 'baseReporterDecorator'];
 
 module.exports = {
   'reporter:kjhtml': ['type', initReporter]


### PR DESCRIPTION
**Issue**: In combination with 'karma-mocha-reporter' it is not possible to suppress the failure messages from 'karma-jasmine-html-reporter' completely. They would show up in between the nicely styled mocha-reporter.

**Fix**: added an options object for the karma config to suppress failure messages. This can be expanded with more settings if someone has a need.

Should be fully backward compatible.

Also updated the Readme.