### PR TITLE
Also create text node if parameter is a number

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-jasmine-html-reporter",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/lib/html.jasmine.reporter.js
+++ b/src/lib/html.jasmine.reporter.js
@@ -653,8 +653,8 @@ jasmineRequire.HtmlReporter = function (j$) {
       for (var i = 2; i < arguments.length; i++) {
         var child = arguments[i];
 
-        if (typeof child === 'string') {
-          el.appendChild(createTextNode(child));
+        if (typeof child === 'string' || typeof child === 'number') {
+          el.appendChild(createTextNode(child.toString()));
         } else {
           if (child) {
             el.appendChild(child);


### PR DESCRIPTION
This fixes an issue that I have in combination with [karma-jasmine-order-reporter](https://www.npmjs.com/package/karma-jasmine-order-reporter).

It often happened that I got errors like this:

```
Chrome Headless 85.0.4183.83 (Linux x86_64) ERROR
  An error was thrown in afterAll
  TypeError: Failed to execute 'appendChild' on 'Node': parameter 1 is not of type 'Node'.
      at <Jasmine>
      at createDom (/home/paul.heising/dev/pwa/node_modules/karma-jasmine-html-reporter/src/lib/html.jasmine.reporter.js:660:16)
      at HtmlReporter.jasmineDone (/home/paul.heising/dev/pwa/node_modules/karma-jasmine-html-reporter/src/lib/html.jasmine.reporter.js:257:11)
```

The reason for this seems to be the seed, that it tries to create a node for, but since the seed comes in as `number`, and not as `string`, it tries to handle it as a `Node`, which fails.