### PR TITLE
Stringify seed when creating DOM

### DIFF
--- a/src/lib/html.jasmine.reporter.js
+++ b/src/lib/html.jasmine.reporter.js
@@ -265,7 +265,7 @@ jasmineRequire.HtmlReporter = function (j$) {
               title: 'randomized with seed ' + order.seed,
               href: seedHref(order.seed)
             },
-            order.seed
+            String(order.seed)
           )
         );
       }


### PR DESCRIPTION
When `karma.conf.js` is configured to use a number for a seed, karma-jasmine-html-reporter will crash at the end. This causes the test run to fail and coverage information to be unavailable even if all tests pass. This crash is unexpected because [the Jasmine specs](https://jasmine.github.io/api/edge/Configuration.html) support specifying seed as a number or a string, so reporters should support either type:

![Screenshot 2021-08-12 at 11 21 02](https://user-images.githubusercontent.com/33226922/129180972-5e039327-27a3-4b82-8276-b0629360e213.png)

This was reported in #19. It's also a fairly common error: [Error: Failed to execute 'appendChild' on 'Node': parameter 1 is not of type 'Node'](https://stackoverflow.com/questions/27079598/error-failed-to-execute-appendchild-on-node-parameter-1-is-not-of-type-no) has 334k views on Stack Overflow.

This fixes that error by converting the seed to a string when it's passed to createDom. To be honestly unnecessarily safe, I've avoided assuming that the seed value exists and has a `toString()` method available and instead use [the global `String()` function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/String) (not constructor) so that it gets stringified no mater what. If we're happy to assume the value exists and has that method, this line could instead be `order.seed.toString()`, but I haven't tested that version.

I did a quick check over other places createDom gets called and this appears to be the only place this string conversion would be needed.

fixes #19

# Verification
Tested in my local by editing the file from inside node_modules then terminating and restarting `npm test`.

In the below screenshots `karma.conf.js` was configured to provide Jasmine with `seed: 123`.

![Screenshot 2021-08-12 at 11 24 53](https://user-images.githubusercontent.com/33226922/129181489-eae58b21-4e39-4274-a789-b993285f8c01.png)

## Old

![Screenshot 2021-08-12 at 11 05 46](https://user-images.githubusercontent.com/33226922/129180184-31098803-1637-49d6-af2d-da7d55fc81b1.png)

## New

![Screenshot 2021-08-12 at 11 06 41](https://user-images.githubusercontent.com/33226922/129180197-92b21957-b647-474f-bc4c-0dce7c94de49.png)